### PR TITLE
Handle other Arris modems

### DIFF
--- a/scripts/arris_sb6190_discover_downstream_channels.sh
+++ b/scripts/arris_sb6190_discover_downstream_channels.sh
@@ -30,9 +30,17 @@ then
 	modemAddress=192.168.100.1
 fi
 
+# some modems use cgi-bin/status
+# other modems use RgConnect.asp
+if [[ $(wget http://${modemAddress}/RgConnect.asp -O-) ]] 2>/dev/null; then
+  modemPath="RgConnect.asp"
+else
+  modemPath="cgi-bin/status"
+fi
+
 
 # Retrieve status webpage and parse tables into XML
-CURL_OUTPUT=$(curl -s http://$modemAddress/cgi-bin/status 2>/dev/null | hxnormalize -x -d -l 256 2> /dev/null | hxselect -i 'table.simpleTable' | sed 's/ kSym\/s//g' | sed 's/ MHz//g' | sed 's/ dBmV//g' | sed 's/ dB//g' | sed 's/<td> */<td>/g')
+CURL_OUTPUT=$(curl -s http://$modemAddress/$modemPath 2>/dev/null | hxnormalize -x -d -l 256 2> /dev/null | hxselect -i 'table.simpleTable' | sed 's/ kSym\/s//g' | sed 's/ MHz//g' | sed 's/ dBmV//g' | sed 's/ dB//g' | sed 's/<td> */<td>/g' | sed 's/&nbsp;//g')
 STATUS_XML="<tables>$CURL_OUTPUT</tables>"
 
 

--- a/scripts/arris_sb6190_discover_upstream_channels.sh
+++ b/scripts/arris_sb6190_discover_upstream_channels.sh
@@ -30,9 +30,17 @@ then
 	modemAddress=192.168.100.1
 fi
 
+# some modems use cgi-bin/status
+# other modems use RgConnect.asp
+if [[ $(wget http://${modemAddress}/RgConnect.asp -O-) ]] 2>/dev/null; then
+  modemPath="RgConnect.asp"
+else
+  modemPath="cgi-bin/status"
+fi
+
 
 # Retrieve status webpage and parse tables into XML
-CURL_OUTPUT=$(curl -s http://$modemAddress/cgi-bin/status 2>/dev/null | hxnormalize -x -d -l 256 2> /dev/null | hxselect -i 'table.simpleTable' | sed 's/ kSym\/s//g' | sed 's/ MHz//g' | sed 's/ dBmV//g' | sed 's/ dB//g' | sed 's/<td> */<td>/g')
+CURL_OUTPUT=$(curl -s http://$modemAddress/$modemPath 2>/dev/null | hxnormalize -x -d -l 256 2> /dev/null | hxselect -i 'table.simpleTable' | sed 's/ kSym\/s//g' | sed 's/ MHz//g' | sed 's/ dBmV//g' | sed 's/ dB//g' | sed 's/<td> */<td>/g' | sed 's/&nbsp;//g')
 STATUS_XML="<tables>$CURL_OUTPUT</tables>"
 
 

--- a/scripts/arris_sb6190_get_status.sh
+++ b/scripts/arris_sb6190_get_status.sh
@@ -29,9 +29,17 @@ then
 	modemAddress=192.168.100.1
 fi
 
+# some modems use cgi-bin/status
+# other modems use RgConnect.asp
+if [[ $(wget http://${modemAddress}/RgConnect.asp -O-) ]] 2>/dev/null; then
+  modemPath="RgConnect.asp"
+else
+  modemPath="cgi-bin/status"
+fi
+
 
 # Retrieve status webpage and parse tables into XML
-CURL_OUTPUT=$(curl -s http://$modemAddress/cgi-bin/status 2>/dev/null | hxnormalize -x -d -l 256 2> /dev/null | hxselect -i 'table.simpleTable' | sed 's/ kSym\/s//g' | sed 's/ MHz//g' | sed 's/ dBmV//g' | sed 's/ dB//g' | sed 's/<td> */<td>/g')
+CURL_OUTPUT=$(curl -s http://$modemAddress/$modemPath 2>/dev/null | hxnormalize -x -d -l 256 2> /dev/null | hxselect -i 'table.simpleTable' | sed 's/ kSym\/s//g' | sed 's/ MHz//g' | sed 's/ dBmV//g' | sed 's/ dB//g' | sed 's/<td> */<td>/g' | sed 's/&nbsp;//g')
 STATUS_XML="<tables>$CURL_OUTPUT</tables>"
 
 echo "{"


### PR DESCRIPTION
The path and formatting for the status page is slightly different
for other Arris modems.  This was tested on an Arris SB6183.

- Add a method to determine which URL to use
- Also filter `&nbsp;` from status page output